### PR TITLE
feat/vitest hooks

### DIFF
--- a/examples/with-typescript-esm/package.json
+++ b/examples/with-typescript-esm/package.json
@@ -16,6 +16,6 @@
     "esbuild-register": "^3.4.2",
     "tinybench": "^2.5.0",
     "typescript": "^5.1.3",
-    "vitest": "^1.0.3"
+    "vitest": "^1.2.2"
   }
 }

--- a/packages/vitest-plugin/README.md
+++ b/packages/vitest-plugin/README.md
@@ -20,7 +20,7 @@ First, install the plugin [`@codspeed/vitest-plugin`](https://www.npmjs.com/pack
 
 > [!NOTE]
 > The CodSpeed plugin is only compatible with
-> [vitest@1.0.0](https://www.npmjs.com/package/vitest/v/1.0.0)
+> [vitest@1.2.2](https://www.npmjs.com/package/vitest/v/1.2.2)
 > and above.
 
 ```sh

--- a/packages/vitest-plugin/benches/hooks.bench.ts
+++ b/packages/vitest-plugin/benches/hooks.bench.ts
@@ -1,0 +1,92 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  bench,
+  describe,
+  expect,
+} from "vitest";
+
+let count = -1;
+
+beforeAll(() => {
+  count += 1;
+});
+
+beforeEach(() => {
+  count += 1;
+});
+
+// the count is multiplied by 2 because the bench function is called twice with codspeed (once for the optimization and once for the actual measurement)
+bench("one", () => {
+  expect(count).toBe(1 * 2);
+});
+
+describe("level1", () => {
+  bench("two", () => {
+    expect(count).toBe(2 * 2);
+  });
+
+  bench("three", () => {
+    expect(count).toBe(3 * 2);
+  });
+
+  describe("level 2", () => {
+    beforeEach(() => {
+      count += 1;
+    });
+
+    bench("five", () => {
+      expect(count).toBe(5 * 2);
+    });
+
+    describe("level 3", () => {
+      bench("seven", () => {
+        expect(count).toBe(7 * 2);
+      });
+    });
+  });
+
+  describe("level 2 bench nested beforeAll", () => {
+    beforeAll(() => {
+      count = 0;
+    });
+
+    bench("one", () => {
+      expect(count).toBe(1 * 2);
+    });
+  });
+
+  bench("two", () => {
+    expect(count).toBe(2 * 2);
+  });
+});
+
+describe("hooks cleanup", () => {
+  let cleanUpCount = 0;
+  describe("run", () => {
+    beforeAll(() => {
+      cleanUpCount += 10;
+    });
+    beforeEach(() => {
+      cleanUpCount += 1;
+    });
+    afterEach(() => {
+      cleanUpCount -= 1;
+    });
+    afterAll(() => {
+      cleanUpCount -= 10;
+    });
+
+    bench("one", () => {
+      expect(cleanUpCount).toBe(11);
+    });
+    bench("two", () => {
+      expect(cleanUpCount).toBe(11);
+    });
+  });
+  bench("end", () => {
+    expect(cleanUpCount).toBe(0);
+  });
+});

--- a/packages/vitest-plugin/package.json
+++ b/packages/vitest-plugin/package.json
@@ -31,12 +31,12 @@
   },
   "peerDependencies": {
     "vite": "^4.2.0 || ^5.0.0",
-    "vitest": ">=1.0.0-beta.4 || >=1"
+    "vitest": ">=1.2.2"
   },
   "devDependencies": {
     "@total-typescript/shoehorn": "^0.1.1",
     "execa": "^8.0.1",
     "vite": "^5.0.0",
-    "vitest": "^1.0.3"
+    "vitest": "^1.2.2"
   }
 }

--- a/packages/vitest-plugin/src/__tests__/index.test.ts
+++ b/packages/vitest-plugin/src/__tests__/index.test.ts
@@ -43,7 +43,7 @@ describe("codSpeedPlugin", () => {
       expect(applyPlugin).toBe(false);
     });
 
-    it("should not apply the plugin when there is no instrumentation", async () => {
+    it("should apply the plugin when there is no instrumentation", async () => {
       coreMocks.Measurement.isInstrumented.mockReturnValue(false);
 
       const applyPlugin = applyPluginFunction(
@@ -52,9 +52,9 @@ describe("codSpeedPlugin", () => {
       );
 
       expect(console.warn).toHaveBeenCalledWith(
-        "[CodSpeed] bench detected but no instrumentation found, falling back to default vitest runner"
+        "[CodSpeed] bench detected but no instrumentation found"
       );
-      expect(applyPlugin).toBe(false);
+      expect(applyPlugin).toBe(true);
     });
 
     it("should apply the plugin when there is instrumentation", async () => {

--- a/packages/vitest-plugin/src/__tests__/runner.test.ts
+++ b/packages/vitest-plugin/src/__tests__/runner.test.ts
@@ -1,5 +1,5 @@
 import { fromPartial } from "@total-typescript/shoehorn";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, Suite, vi } from "vitest";
 import { getBenchFn } from "vitest/suite";
 import CodSpeedRunner from "../runner";
 
@@ -25,21 +25,31 @@ vi.mock("@codspeed/core", async (importOriginal) => {
 
 console.log = vi.fn();
 
-vi.mock("vitest/suite");
+vi.mock("vitest/suite", () => ({
+  getBenchFn: vi.fn(),
+  // wrapping the value in vi.fn(...) here will not work for some reason
+  getHooks: () => ({
+    beforeAll: [],
+    beforeEach: [],
+    afterEach: [],
+    afterAll: [],
+  }),
+}));
 const mockedGetBenchFn = vi.mocked(getBenchFn);
+
 describe("CodSpeedRunner", () => {
   it("should run the bench functions only twice", async () => {
     const benchFn = vi.fn();
     mockedGetBenchFn.mockReturnValue(benchFn);
 
     const runner = new CodSpeedRunner(fromPartial({}));
-    await runner.runSuite(
-      fromPartial({
-        filepath: __filename,
-        name: "test suite",
-        tasks: [{ mode: "run", meta: { benchmark: true }, name: "test bench" }],
-      })
-    );
+    const suite = fromPartial<Suite>({
+      filepath: __filename,
+      name: "test suite",
+      tasks: [{ mode: "run", meta: { benchmark: true }, name: "test bench" }],
+    });
+    suite.tasks[0].suite = suite;
+    await runner.runSuite(suite);
 
     // setup
     expect(coreMocks.setupCore).toHaveBeenCalledTimes(1);
@@ -71,26 +81,29 @@ describe("CodSpeedRunner", () => {
     mockedGetBenchFn.mockReturnValue(benchFn);
 
     const runner = new CodSpeedRunner(fromPartial({}));
-    await runner.runSuite(
-      fromPartial({
-        filepath: __filename,
-        name: "test suite",
-        tasks: [
-          {
-            type: "suite",
-            name: "nested suite",
-            mode: "run",
-            tasks: [
-              {
-                mode: "run",
-                meta: { benchmark: true },
-                name: "test bench",
-              },
-            ],
-          },
-        ],
-      })
-    );
+    const rootSuite = fromPartial<Suite>({
+      filepath: __filename,
+      name: "test suite",
+      tasks: [
+        {
+          type: "suite",
+          name: "nested suite",
+          mode: "run",
+          tasks: [
+            {
+              mode: "run",
+              meta: { benchmark: true },
+              name: "test bench",
+            },
+          ],
+        },
+      ],
+    });
+    rootSuite.tasks[0].suite = rootSuite;
+    // @ts-expect-error type is not narrow enough, but it is fine
+    rootSuite.tasks[0].tasks[0].suite = rootSuite.tasks[0];
+
+    await runner.runSuite(rootSuite);
 
     // setup
     expect(coreMocks.setupCore).toHaveBeenCalledTimes(1);

--- a/packages/vitest-plugin/src/index.ts
+++ b/packages/vitest-plugin/src/index.ts
@@ -27,10 +27,7 @@ export default function codspeedPlugin(): Plugin {
         return false;
       }
       if (!Measurement.isInstrumented()) {
-        console.warn(
-          `[CodSpeed] bench detected but no instrumentation found, falling back to default vitest runner`
-        );
-        return false;
+        console.warn("[CodSpeed] bench detected but no instrumentation found");
       }
       return true;
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3
       vitest:
-        specifier: ^1.0.3
-        version: 1.0.3(@types/node@18.15.11)
+        specifier: ^1.2.2
+        version: 1.2.2(@types/node@18.15.11)
 
   examples/with-typescript-simple-cjs:
     devDependencies:
@@ -321,8 +321,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@18.15.11)
       vitest:
-        specifier: ^1.0.3
-        version: 1.0.3(@types/node@18.15.11)
+        specifier: ^1.2.2
+        version: 1.2.2(@types/node@18.15.11)
 
 packages:
   /@ampproject/remapping@2.2.1:
@@ -4861,32 +4861,32 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /@vitest/expect@1.0.3:
+  /@vitest/expect@1.2.2:
     resolution:
       {
-        integrity: sha512-J+JzGw/uvlWI3D3g8s0ewQo7C32nieF5VqEJpmIgAr8CAK36GvIQrV90lChEgQy79iwK3zyQx4UhfMeIF4572g==,
+        integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==,
       }
     dependencies:
-      "@vitest/spy": 1.0.3
-      "@vitest/utils": 1.0.3
+      "@vitest/spy": 1.2.2
+      "@vitest/utils": 1.2.2
       chai: 4.3.10
     dev: true
 
-  /@vitest/runner@1.0.3:
+  /@vitest/runner@1.2.2:
     resolution:
       {
-        integrity: sha512-fCqShW4F8VJ78USVRoc5e1OD5jh1x1quZu4Mgp/lIhZS6PZPtI3wdCfRChWO9ZMJ2Ya7WI3sZTJZD69FR/AosA==,
+        integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==,
       }
     dependencies:
-      "@vitest/utils": 1.0.3
+      "@vitest/utils": 1.2.2
       p-limit: 5.0.0
       pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@1.0.3:
+  /@vitest/snapshot@1.2.2:
     resolution:
       {
-        integrity: sha512-2EQwVEuHusEXr0SKuFiI1JVlysSrUceejtusr6vK254tusAz/g4//QrAiD1b7PMdcUKM8QmdgWvqCMaYDsWyNA==,
+        integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==,
       }
     dependencies:
       magic-string: 0.30.5
@@ -4894,22 +4894,23 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.0.3:
+  /@vitest/spy@1.2.2:
     resolution:
       {
-        integrity: sha512-aMd7kvqJuZ/h27Q5XqNOh9fRX7cQJ9fcaPX8q/lk5h2MkAqvq/HuqZ7n1xjm2SDOlDqg3xMaEqP/4inNlNG62A==,
+        integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==,
       }
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/utils@1.0.3:
+  /@vitest/utils@1.2.2:
     resolution:
       {
-        integrity: sha512-ddGKC6CVjxwjA+ourSlMD6Emc+PhIH6+d25ISGBOQjryXi2NtKpsBSOt1yDT793c2Tqij8g8BBxe87jam3B95w==,
+        integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==,
       }
     dependencies:
       diff-sequences: 29.6.3
+      estree-walker: 3.0.3
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
@@ -4997,10 +4998,10 @@ packages:
     engines: { node: ">=0.4.0" }
     dev: true
 
-  /acorn-walk@8.3.1:
+  /acorn-walk@8.3.2:
     resolution:
       {
-        integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==,
+        integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==,
       }
     engines: { node: ">=0.4.0" }
     dev: true
@@ -7242,6 +7243,15 @@ packages:
       {
         integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
       }
+    dev: true
+
+  /estree-walker@3.0.3:
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
+    dependencies:
+      "@types/estree": 1.0.0
     dev: true
 
   /esutils@2.0.3:
@@ -13203,10 +13213,10 @@ packages:
       }
     dev: true
 
-  /tinypool@0.8.1:
+  /tinypool@0.8.2:
     resolution:
       {
-        integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==,
+        integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==,
       }
     engines: { node: ">=14.0.0" }
     dev: true
@@ -13802,10 +13812,10 @@ packages:
       builtins: 5.0.1
     dev: true
 
-  /vite-node@1.0.3(@types/node@18.15.11):
+  /vite-node@1.2.2(@types/node@18.15.11):
     resolution:
       {
-        integrity: sha512-7AH08/UgJQm4gWFyXB6xQ1AvI+iMioM2duPmptytxEbkHamVrOhoha4REt9xvOgyiw91G9OykRlixN4zIsQOQg==,
+        integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==,
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
@@ -13865,10 +13875,10 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.0.3(@types/node@18.15.11):
+  /vitest@1.2.2(@types/node@18.15.11):
     resolution:
       {
-        integrity: sha512-zbMmAdRjTki6mYXEjCXMVH8Vb0FX0rAfCSTrbbn3Dqd8Zz6FzImBavkKYsOF+iXd4+k5RoOqi6RyTSoroRS0mw==,
+        integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==,
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
@@ -13894,12 +13904,12 @@ packages:
         optional: true
     dependencies:
       "@types/node": 18.15.11
-      "@vitest/expect": 1.0.3
-      "@vitest/runner": 1.0.3
-      "@vitest/snapshot": 1.0.3
-      "@vitest/spy": 1.0.3
-      "@vitest/utils": 1.0.3
-      acorn-walk: 8.3.1
+      "@vitest/expect": 1.2.2
+      "@vitest/runner": 1.2.2
+      "@vitest/snapshot": 1.2.2
+      "@vitest/spy": 1.2.2
+      "@vitest/utils": 1.2.2
+      acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
@@ -13911,9 +13921,9 @@ packages:
       std-env: 3.6.0
       strip-literal: 1.3.0
       tinybench: 2.5.1
-      tinypool: 0.8.1
+      tinypool: 0.8.2
       vite: 5.0.0(@types/node@18.15.11)
-      vite-node: 1.0.3(@types/node@18.15.11)
+      vite-node: 1.2.2(@types/node@18.15.11)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
- feat(vitest-plugin): add support for benchmark hooks
- feat(vitest-plugin): always run codspeed benchmarks when using the plugin, as hooks are not supported in the default vitest benchmark runner