### PR TITLE
fix(vitest-plugin): ensure typings are found when using exports

### DIFF
--- a/packages/vitest-plugin/package.json
+++ b/packages/vitest-plugin/package.json
@@ -12,6 +12,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
     }
   },


### PR DESCRIPTION
Fix #34
