### PR TITLE
feat: vitest-plugin - allow vite 6 in peer dependencies

### DIFF
--- a/packages/vitest-plugin/package.json
+++ b/packages/vitest-plugin/package.json
@@ -31,7 +31,7 @@
     "@codspeed/core": "workspace:^4.0.0"
   },
   "peerDependencies": {
-    "vite": "^4.2.0 || ^5.0.0",
+    "vite": "^4.2.0 || ^5.0.0 || ^6.0.0",
     "vitest": ">=1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Should fix issue #42 

vite 3.0 uses vite 6. On my repos I haven't noticed incompatibilities with vite 6. 

Let me know if there's other things to check