### PR TITLE
chore: remove concurrency call and pin action version to have a base run before action v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run benchmarks with tinybench-plugin
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@main
+        uses: CodSpeedHQ/action@v3
         with:
           run: pnpm --filter ${{ matrix.example }} bench-tinybench
         env:
@@ -70,7 +70,7 @@ jobs:
           CODSPEED_DEBUG: true
       - name: Run benchmarks with benchmark.js-plugin
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@main
+        uses: CodSpeedHQ/action@v3
         with:
           run: pnpm --filter ${{ matrix.example }} bench-benchmark-js
         env:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,10 +25,12 @@ jobs:
 
       - name: Run benchmarks
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@main
+        uses: CodSpeedHQ/action@v3
         with:
           run: |
-            pnpm moon run --concurrency 1 :bench
+            pnpm moon run tinybench-plugin:bench
+            pnpm moon run vitest-plugin:bench
+            pnpm moon run benchmark.js-plugin:bench
             pnpm --workspace-concurrency 1 -r bench-tinybench
             pnpm --workspace-concurrency 1 -r bench-benchmark-js
             pnpm --workspace-concurrency 1 -r bench-vitest
@@ -51,10 +53,11 @@ jobs:
 
       - name: Run benchmarks
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@main
+        uses: CodSpeedHQ/action@v3
         with:
-          # Only tinybench supports walltime for now
           run: |
-            pnpm moon run --concurrency 1 :bench
+            pnpm moon run tinybench-plugin:bench
+            pnpm moon run vitest-plugin:bench
+            pnpm moon run benchmark.js-plugin:bench
             pnpm --workspace-concurrency 1 -r bench-tinybench
             pnpm --workspace-concurrency 1 -r bench-vitest


### PR DESCRIPTION
For better traceability, we pin the action to v3, which was the previous base run version, and then we make the changes that are necessary for v4 to work.

In a subsequent PR, we'll bump the action to v4, to isolate the effects of each change and have better visibility