### PR TITLE
ci: bump action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,16 +62,18 @@ jobs:
 
       - name: Run benchmarks with tinybench-plugin
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@main
         with:
+          mode: instrumentation
           run: pnpm --filter ${{ matrix.example }} bench-tinybench
         env:
           CODSPEED_SKIP_UPLOAD: true
           CODSPEED_DEBUG: true
       - name: Run benchmarks with benchmark.js-plugin
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@main
         with:
+          mode: instrumentation
           run: pnpm --filter ${{ matrix.example }} bench-benchmark-js
         env:
           CODSPEED_SKIP_UPLOAD: true

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Run benchmarks
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@main
         with:
+          mode: instrumentation
           run: |
             pnpm moon run tinybench-plugin:bench
             pnpm moon run vitest-plugin:bench
@@ -53,8 +54,9 @@ jobs:
 
       - name: Run benchmarks
         # use version from `main` branch to always test the latest version, in real projects, use a tag, like `@v2`
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@main
         with:
+          mode: walltime
           run: |
             pnpm moon run tinybench-plugin:bench
             pnpm moon run vitest-plugin:bench

--- a/packages/core/src/introspection.ts
+++ b/packages/core/src/introspection.ts
@@ -1,28 +1,35 @@
 import { writeFileSync } from "fs";
+import { getCodspeedRunnerMode } from ".";
 
 const CUSTOM_INTROSPECTION_EXIT_CODE = 0;
 
 export const getV8Flags = () => {
   const nodeVersionMajor = parseInt(process.version.slice(1).split(".")[0]);
+  const codspeedRunnerMode = getCodspeedRunnerMode();
 
-  const flags = [
-    "--hash-seed=1",
-    "--random-seed=1",
-    "--no-opt",
-    "--predictable",
-    "--predictable-gc-schedule",
-    "--interpreted-frames-native-stack",
-    "--allow-natives-syntax",
-    "--expose-gc",
-    "--no-concurrent-sweeping",
-    "--max-old-space-size=4096",
-  ];
-  if (nodeVersionMajor < 18) {
-    flags.push("--no-randomize-hashes");
+  const flags = ["--interpreted-frames-native-stack", "--allow-natives-syntax"];
+
+  if (codspeedRunnerMode === "instrumented") {
+    flags.push(
+      ...[
+        "--hash-seed=1",
+        "--random-seed=1",
+        "--no-opt",
+        "--predictable",
+        "--predictable-gc-schedule",
+        "--expose-gc",
+        "--no-concurrent-sweeping",
+        "--max-old-space-size=4096",
+      ]
+    );
+    if (nodeVersionMajor < 18) {
+      flags.push("--no-randomize-hashes");
+    }
+    if (nodeVersionMajor < 20) {
+      flags.push("--no-scavenge-task");
+    }
   }
-  if (nodeVersionMajor < 20) {
-    flags.push("--no-scavenge-task");
-  }
+
   return flags;
 };
 

--- a/packages/vitest-plugin/src/__tests__/index.test.ts
+++ b/packages/vitest-plugin/src/__tests__/index.test.ts
@@ -93,13 +93,13 @@ describe("codSpeedPlugin", () => {
         poolOptions: {
           forks: {
             execArgv: [
+              "--interpreted-frames-native-stack",
+              "--allow-natives-syntax",
               "--hash-seed=1",
               "--random-seed=1",
               "--no-opt",
               "--predictable",
               "--predictable-gc-schedule",
-              "--interpreted-frames-native-stack",
-              "--allow-natives-syntax",
               "--expose-gc",
               "--no-concurrent-sweeping",
               "--max-old-space-size=4096",


### PR DESCRIPTION
## Explanation

Tinybench relies on the node.sh introspection script be present in the runner ([tryIntrospect()](https://github.com/CodSpeedHQ/codspeed-node/blob/9481178cd8b8bd50bdb518d4c8b3100807e729c7/packages/core/src/introspection.ts#L40-L51) call when importing the tinybench module)

Vitest actually uses the flag no matter what

So what happens is:
1. Enabling introspection makes tinybench use the flags from getV8Flags
2. Even with introspection disabled, vitest was already using flags from getV8Flags
3. Bumping the action enabled introspection for walltime
    a. tinybench got performance regression in walltime
    b.vitest does not change because it was already using the flags
4. Changing the flags from getV8Flags to remove flags like no-opt used in instrumented mode
    a. fixes tinybench regression caused by action bump
    b. enhances vitest performance because vitest no longer uses flags like no-opt

### TLDR

Bumped the action, fixed the walltime flags for getV8Flags -> vitest performance bump