### PR TITLE
feat: rename instrumentation to simulation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export const isBound = native_core.isBound;
 
 export const mongoMeasurement = new MongoMeasurement();
 
-type CodSpeedRunnerMode = "disabled" | "instrumented" | "walltime";
+type CodSpeedRunnerMode = "disabled" | "simulation" | "walltime";
 
 export function getCodspeedRunnerMode(): CodSpeedRunnerMode {
   const isCodSpeedEnabled = process.env.CODSPEED_ENV !== undefined;
@@ -20,8 +20,11 @@ export function getCodspeedRunnerMode(): CodSpeedRunnerMode {
 
   // If CODSPEED_ENV is set, check CODSPEED_RUNNER_MODE
   const codspeedRunnerMode = process.env.CODSPEED_RUNNER_MODE;
-  if (codspeedRunnerMode === "instrumentation") {
-    return "instrumented";
+  if (
+    codspeedRunnerMode === "instrumentation" ||
+    codspeedRunnerMode === "simulation"
+  ) {
+    return "simulation";
   } else if (codspeedRunnerMode === "walltime") {
     return "walltime";
   }

--- a/packages/core/src/introspection.ts
+++ b/packages/core/src/introspection.ts
@@ -9,7 +9,7 @@ export const getV8Flags = () => {
 
   const flags = ["--interpreted-frames-native-stack", "--allow-natives-syntax"];
 
-  if (codspeedRunnerMode === "instrumented") {
+  if (codspeedRunnerMode === "simulation") {
     flags.push(
       ...[
         "--hash-seed=1",

--- a/packages/tinybench-plugin/src/index.ts
+++ b/packages/tinybench-plugin/src/index.ts
@@ -11,7 +11,7 @@ import path from "path";
 import { get as getStackTrace } from "stack-trace";
 import { Bench } from "tinybench";
 import { fileURLToPath } from "url";
-import { setupCodspeedInstrumentedBench } from "./instrumented";
+import { setupCodspeedSimulationBench } from "./simulation";
 import { getOrCreateUriMap } from "./uri";
 import { setupCodspeedWalltimeBench } from "./walltime";
 
@@ -39,8 +39,8 @@ export function withCodSpeed(bench: Bench): Bench {
     return rawAdd.bind(bench)(name, fn, opts);
   };
 
-  if (codspeedRunnerMode === "instrumented") {
-    setupCodspeedInstrumentedBench(bench, rootCallingFile);
+  if (codspeedRunnerMode === "simulation") {
+    setupCodspeedSimulationBench(bench, rootCallingFile);
   } else if (codspeedRunnerMode === "walltime") {
     setupCodspeedWalltimeBench(bench, rootCallingFile);
   }

--- a/packages/tinybench-plugin/src/index.unit.test.ts
+++ b/packages/tinybench-plugin/src/index.unit.test.ts
@@ -2,12 +2,12 @@ import { Bench } from "tinybench";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withCodSpeed } from ".";
 
-const mockInstrumented = vi.hoisted(() => ({
-  setupCodspeedInstrumentedBench: vi.fn(),
+const mockSimulation = vi.hoisted(() => ({
+  setupCodspeedSimulationBench: vi.fn(),
 }));
 
-vi.mock("./instrumented", () => ({
-  ...mockInstrumented,
+vi.mock("./simulation", () => ({
+  ...mockSimulation,
 }));
 
 const mockWalltime = vi.hoisted(() => ({
@@ -38,13 +38,23 @@ describe("withCodSpeed behavior without different codspeed modes", () => {
     expect(shouldBeCalled.mock.calls.length).toBeGreaterThan(1000);
   });
 
-  it("should run in instrumented mode when CODSPEED_RUNNER_MODE=instrumentation", async () => {
+  it("should run in simulation mode when CODSPEED_RUNNER_MODE=instrumentation", async () => {
     process.env.CODSPEED_ENV = "true";
     process.env.CODSPEED_RUNNER_MODE = "instrumentation";
 
     withCodSpeed(new Bench());
 
-    expect(mockInstrumented.setupCodspeedInstrumentedBench).toHaveBeenCalled();
+    expect(mockSimulation.setupCodspeedSimulationBench).toHaveBeenCalled();
+    expect(mockWalltime.setupCodspeedWalltimeBench).not.toHaveBeenCalled();
+  });
+
+  it("should run in simulation mode when CODSPEED_RUNNER_MODE=simulation", async () => {
+    process.env.CODSPEED_ENV = "true";
+    process.env.CODSPEED_RUNNER_MODE = "simulation";
+
+    withCodSpeed(new Bench());
+
+    expect(mockSimulation.setupCodspeedSimulationBench).toHaveBeenCalled();
     expect(mockWalltime.setupCodspeedWalltimeBench).not.toHaveBeenCalled();
   });
 
@@ -54,9 +64,7 @@ describe("withCodSpeed behavior without different codspeed modes", () => {
 
     withCodSpeed(new Bench());
 
-    expect(
-      mockInstrumented.setupCodspeedInstrumentedBench
-    ).not.toHaveBeenCalled();
+    expect(mockSimulation.setupCodspeedSimulationBench).not.toHaveBeenCalled();
     expect(mockWalltime.setupCodspeedWalltimeBench).toHaveBeenCalled();
   });
 });

--- a/packages/tinybench-plugin/src/simulation.ts
+++ b/packages/tinybench-plugin/src/simulation.ts
@@ -6,17 +6,17 @@ import {
 import { Bench, Fn, FnOptions, Task } from "tinybench";
 import { BaseBenchRunner } from "./shared";
 
-export function setupCodspeedInstrumentedBench(
+export function setupCodspeedSimulationBench(
   bench: Bench,
   rootCallingFile: string
 ): void {
-  const runner = new InstrumentedBenchRunner(bench, rootCallingFile);
+  const runner = new SimulationBenchRunner(bench, rootCallingFile);
   runner.setupBenchMethods();
 }
 
-class InstrumentedBenchRunner extends BaseBenchRunner {
+class SimulationBenchRunner extends BaseBenchRunner {
   protected getModeName(): string {
-    return "instrumented mode";
+    return "simulation mode";
   }
 
   private taskCompletionMessage() {

--- a/packages/tinybench-plugin/tests/__snapshots__/index.integ.test.ts.snap
+++ b/packages/tinybench-plugin/tests/__snapshots__/index.integ.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Benchmark.Suite > check console output(instrumented=%p)  false 1`] = `
 {
   "log": [
     [
-      "[CodSpeed] running with @codspeed/tinybench v1.0.0 (instrumented mode)",
+      "[CodSpeed] running with @codspeed/tinybench v1.0.0 (simulation mode)",
     ],
     [
       "[CodSpeed] Checked packages/tinybench-plugin/tests/index.integ.test.ts::RegExp",

--- a/packages/vitest-plugin/rollup.config.ts
+++ b/packages/vitest-plugin/rollup.config.ts
@@ -21,8 +21,8 @@ export default defineConfig([
     external: ["@codspeed/core", /^vitest/],
   },
   {
-    input: "src/instrumented.ts",
-    output: { file: "dist/instrumented.mjs", format: "es" },
+    input: "src/simulation.ts",
+    output: { file: "dist/simulation.mjs", format: "es" },
     plugins: jsPlugins(pkg.version),
     external: ["@codspeed/core", /^vitest/],
   },

--- a/packages/vitest-plugin/src/__tests__/index.test.ts
+++ b/packages/vitest-plugin/src/__tests__/index.test.ts
@@ -107,7 +107,7 @@ describe("codSpeedPlugin", () => {
           },
         },
         runner: expect.stringContaining(
-          "packages/vitest-plugin/src/instrumented.ts"
+          "packages/vitest-plugin/src/simulation.ts"
         ),
       },
     });

--- a/packages/vitest-plugin/src/__tests__/instrumented.test.ts
+++ b/packages/vitest-plugin/src/__tests__/instrumented.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from "@total-typescript/shoehorn";
 import { describe, expect, it, vi, type RunnerTestSuite } from "vitest";
 import { getBenchFn } from "vitest/suite";
-import { InstrumentedRunner as CodSpeedRunner } from "../instrumented";
+import { SimulationRunner as CodSpeedRunner } from "../simulation";
 
 const coreMocks = vi.hoisted(() => {
   return {

--- a/packages/vitest-plugin/src/index.ts
+++ b/packages/vitest-plugin/src/index.ts
@@ -37,7 +37,7 @@ export default function codspeedPlugin(): Plugin {
         return false;
       }
       if (
-        getCodspeedRunnerMode() == "instrumented" &&
+        getCodspeedRunnerMode() == "simulation" &&
         !InstrumentHooks.isInstrumented()
       ) {
         console.warn("[CodSpeed] bench detected but no instrumentation found");

--- a/packages/vitest-plugin/src/runner.ts
+++ b/packages/vitest-plugin/src/runner.ts
@@ -1,3 +1,3 @@
-import { InstrumentedRunner } from "./instrumented";
+import { SimulationRunner } from "./simulation";
 
-export default InstrumentedRunner;
+export default SimulationRunner;

--- a/packages/vitest-plugin/src/simulation.ts
+++ b/packages/vitest-plugin/src/simulation.ts
@@ -18,7 +18,7 @@ import {
 const currentFileName =
   typeof __filename === "string"
     ? __filename
-    : new URL("instrumented.mjs", import.meta.url).pathname;
+    : new URL("simulation.mjs", import.meta.url).pathname;
 
 /**
  * @deprecated
@@ -29,7 +29,7 @@ function logCodSpeed(message: string) {
   console.log(`[CodSpeed] ${message}`);
 }
 
-async function runInstrumentedBench(
+async function runSimulationBench(
   benchmark: Benchmark,
   suite: RunnerTestSuite,
   currentSuiteName: string
@@ -60,7 +60,7 @@ async function runInstrumentedBench(
   logCodSpeed(`${uri} done`);
 }
 
-async function runInstrumentedBenchmarkSuite(
+async function runSimulationBenchmarkSuite(
   suite: RunnerTestSuite,
   parentSuiteName?: string
 ) {
@@ -74,16 +74,16 @@ async function runInstrumentedBenchmarkSuite(
     if (task.mode !== "run") continue;
 
     if (isVitestTaskBenchmark(task)) {
-      await runInstrumentedBench(task, suite, currentSuiteName);
+      await runSimulationBench(task, suite, currentSuiteName);
     } else if (task.type === "suite") {
-      await runInstrumentedBenchmarkSuite(task, currentSuiteName);
+      await runSimulationBenchmarkSuite(task, currentSuiteName);
     }
   }
 
   await callSuiteHook(suite, suite, "afterAll");
 }
 
-export class InstrumentedRunner extends NodeBenchmarkRunner {
+export class SimulationRunner extends NodeBenchmarkRunner {
   async runSuite(suite: RunnerTestSuite): Promise<void> {
     logDebug(`PROCESS PID: ${process.pid} in ${currentFileName}`);
     setupCore();
@@ -91,11 +91,11 @@ export class InstrumentedRunner extends NodeBenchmarkRunner {
     patchRootSuiteWithFullFilePath(suite);
 
     logCodSpeed(`running suite ${suite.name}`);
-    await runInstrumentedBenchmarkSuite(suite);
+    await runSimulationBenchmarkSuite(suite);
     logCodSpeed(`running suite ${suite.name} done`);
 
     teardownCore();
   }
 }
 
-export default InstrumentedRunner;
+export default SimulationRunner;


### PR DESCRIPTION
`instrumentation` is still accepted as an input, but it maps to simulation internally, as we plan to phase it out.