### PR TITLE
ci(release): publish any prerelease tag under its own dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,24 @@ jobs:
       - if: github.event_name == 'push'
         name: Publish the libraries
         run: |
-          if [[ "${{ github.ref }}" == *"-alpha"* ]]; then
-            pnpm publish -r --access=public --no-git-checks --tag=alpha
-          else
+          # Prerelease tags publish under their own identifier (alpha, beta, rc);
+          # only a plain vX.Y.Z tag is allowed to move the `latest` dist-tag.
+          VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$VERSION" != *-* ]]; then
             pnpm publish -r --access=public --no-git-checks
+            exit 0
           fi
+
+          PREID="${VERSION#*-}"
+          PREID="${PREID%%.*}"
+          # npm rejects a dist-tag that parses as a semver range, so a numeric
+          # identifier has no channel to publish under, and `latest` is the
+          # stable channel a prerelease must never take over.
+          if [[ ! "$PREID" =~ ^[A-Za-z][A-Za-z0-9-]*$ || "${PREID,,}" == "latest" ]]; then
+            echo "Refusing to publish $GITHUB_REF_NAME: '$PREID' cannot be a prerelease dist-tag" >&2
+            exit 1
+          fi
+          pnpm publish -r --access=public --no-git-checks --tag="$PREID"
         env:
           NPM_CONFIG_PROVENANCE: true
           # Surfaces npm's OIDC token exchange, which is otherwise silent.
@@ -85,6 +98,10 @@ jobs:
         name: Create a draft release
         run: |
           NEW_VERSION=$(pnpm lerna list --json | jq -r '.[] | select(.name == "@codspeed/core") | .version')
-          gh release create v$NEW_VERSION --title "v$NEW_VERSION" --generate-notes -d
+          PRERELEASE=""
+          if [[ "$NEW_VERSION" == *-* ]]; then
+            PRERELEASE="--prerelease"
+          fi
+          gh release create "v$NEW_VERSION" --title "v$NEW_VERSION" --generate-notes -d $PRERELEASE
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+## Releasing a New Version
+
+To create a new version, run:
+
+```bash
+./scripts/release.sh patch  # Increment PATCH component (e.g., 1.2.3 -> 1.2.4)
+./scripts/release.sh minor  # Increment MINOR component (e.g., 1.2.3 -> 1.3.0)
+./scripts/release.sh major  # Increment MAJOR component (e.g., 1.2.3 -> 2.0.0)
+```
+
+All packages share a single version, bumped in lockstep by `lerna version`.
+
+### Prereleases
+
+A new prerelease series is started by passing the version explicitly, and
+continued with `prerelease`, which keeps the identifier it already has (the
+label between the `-` and the counter):
+
+```bash
+./scripts/release.sh 5.8.0-beta.0  # 5.7.1        -> 5.8.0-beta.0
+./scripts/release.sh prerelease    # 5.8.0-beta.0 -> 5.8.0-beta.1
+```
+
+The identifier becomes the npm dist-tag, so a prerelease is installed only by
+asking for it:
+
+```bash
+pnpm add @codspeed/vitest-plugin@beta
+```
+
+`latest` keeps pointing at the most recent stable release, and `^5` never
+resolves to a prerelease.
+
+### What happens
+
+1. **`scripts/release.sh`**:
+   - Refuses to run outside `main` or with a dirty working tree
+   - Runs `lerna version`, which bumps every package, commits, creates a signed
+     `vX.Y.Z` tag and pushes it
+
+2. **CI release workflow** (`.github/workflows/release.yml`):
+   - Triggered automatically when the tag is pushed
+   - Builds the native addon prebuilds for linux-arm and darwin-arm
+   - Builds the libraries
+   - Publishes to npm via OIDC trusted publishing, under the dist-tag derived
+     from the tag's prerelease identifier (`latest` for a plain `vX.Y.Z` tag)
+   - Creates a draft GitHub release, flagged as a prerelease when the version
+     has a prerelease identifier

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
-# Usage: ./scripts/release.sh <major|minor|patch|premajor|preminor|prepatch|prerelease> [preid]
+#
+# Usage: ./scripts/release.sh <version>
+#
+#   version   major | minor | patch   stable release
+#             prerelease              next prerelease of the current version,
+#                                     keeping its identifier
+#             X.Y.Z-<id>.N            explicit version, used to start a new
+#                                     prerelease series
+#
+# The identifier of a prerelease version (e.g. "beta" in 5.8.0-beta.0) becomes
+# the npm dist-tag the release workflow publishes under, so consumers opt in
+# with `pnpm add @codspeed/core@beta` while `latest` keeps pointing at the last
+# stable release.
+#
+#   ./scripts/release.sh patch          5.7.1        -> 5.7.2         (dist-tag latest)
+#   ./scripts/release.sh 5.8.0-beta.0   5.7.1        -> 5.8.0-beta.0  (dist-tag beta)
+#   ./scripts/release.sh prerelease     5.8.0-beta.0 -> 5.8.0-beta.1  (dist-tag beta)
 set -ex
 
 # Fail if not on main
@@ -8,24 +24,12 @@ if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
   exit 1
 fi
 
-if [ $# -lt 1 ] || [ $# -gt 2 ]; then
-  echo "Usage: ./release.sh <major|minor|patch|premajor|preminor|prepatch|prerelease> [preid]"
+if [ $# -ne 1 ]; then
+  echo "Usage: ./release.sh <major|minor|patch|prerelease|X.Y.Z-id.N>"
   exit 1
-fi
-
-# lerna defaults the prerelease identifier to "alpha"; the dist-tag the release
-# workflow publishes under is derived from it, so it must be spelled out for
-# any other channel.
-PREID=()
-if [ $# -eq 2 ]; then
-  if [[ ! "$2" =~ ^[a-z][a-z0-9-]*$ || "$2" == "latest" ]]; then
-    echo "Invalid prerelease identifier: '$2' (expected e.g. alpha, beta, rc)"
-    exit 1
-  fi
-  PREID=(--preid "$2")
 fi
 
 # Fail if there are any unstaged changes left
 git diff --exit-code
 
-pnpm lerna version "$1" "${PREID[@]}" --force-publish --no-private --sign-git-tag
+pnpm lerna version "$1" --force-publish --no-private --sign-git-tag

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Usage: ./scripts/release.sh <major|minor|patch>
+# Usage: ./scripts/release.sh <major|minor|patch|premajor|preminor|prepatch|prerelease> [preid]
 set -ex
 
 # Fail if not on main
@@ -8,12 +8,24 @@ if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
   exit 1
 fi
 
-if [ $# -ne 1 ]; then
-  echo "Usage: ./release.sh <major|minor|patch>"
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: ./release.sh <major|minor|patch|premajor|preminor|prepatch|prerelease> [preid]"
   exit 1
+fi
+
+# lerna defaults the prerelease identifier to "alpha"; the dist-tag the release
+# workflow publishes under is derived from it, so it must be spelled out for
+# any other channel.
+PREID=()
+if [ $# -eq 2 ]; then
+  if [[ ! "$2" =~ ^[a-z][a-z0-9-]*$ || "$2" == "latest" ]]; then
+    echo "Invalid prerelease identifier: '$2' (expected e.g. alpha, beta, rc)"
+    exit 1
+  fi
+  PREID=(--preid "$2")
 fi
 
 # Fail if there are any unstaged changes left
 git diff --exit-code
 
-pnpm lerna version "$1" --force-publish --no-private --sign-git-tag
+pnpm lerna version "$1" "${PREID[@]}" --force-publish --no-private --sign-git-tag


### PR DESCRIPTION
## Problem

The publish step matched only `-alpha` in the tag name:

```bash
if [[ "${{ github.ref }}" == *"-alpha"* ]]; then
  pnpm publish -r --access=public --no-git-checks --tag=alpha
else
  pnpm publish -r --access=public --no-git-checks   # v5.8.0-beta.1 lands here
fi
```

Any other prerelease identifier fell through to the `else` branch and moved the `latest` dist-tag, so a beta or rc would have been installed by every consumer on `^5`. Beta was also unreachable in the first place: `scripts/release.sh` forwards a single positional to `lerna version` with no `--preid`, and lerna defaults the prerelease identifier to `alpha`, which is precisely why the workflow only ever needed to check for `-alpha`.

## Changes

- Derive the dist-tag from the tag's prerelease identifier rather than hardcoding one channel. `beta`, `rc` and `next` are covered by the same rule, and `latest` is now reserved for plain `vX.Y.Z` tags — the fail-closed direction, where an unrecognised suffix gets its own tag instead of clobbering `latest`. This also drops the loose substring match: `v5.8.0-alphabet.1` previously published as `alpha`.
- Flag the draft GitHub release `--prerelease` when the version contains a `-` (this was missing for alpha too).
- `scripts/release.sh` takes an optional second argument forwarded as `--preid`, so `./scripts/release.sh prerelease beta` produces `5.7.2-beta.0` and the matching tag.

Both shell snippets avoid `[[ ... ]] && VAR=...` as a final command, since workflow steps run under `bash -e` where a false test fails the step.

## Verification

No release was performed. `pnpm`, `gh` and `git` were replaced with echo-only stubs, and the workflow bodies were extracted verbatim from the YAML file, so these are the argv the shipped text builds:

| git tag | publish command |
| --- | --- |
| `v5.8.0` | `pnpm publish -r --access=public --no-git-checks` |
| `v5.8.0-alpha.0` | `... --tag=alpha` |
| `v5.8.0-beta.1` | `... --tag=beta` |
| `v5.8.0-rc.0` | `... --tag=rc` |
| `v5.8.0-next.3` | `... --tag=next` |
| `v5.8.0-alphabet.1` | `... --tag=alphabet` |

- Draft release: `5.8.0` gets no flag, `5.8.0-beta.1` and `5.8.0-alpha.0` get `--prerelease`. All steps exit 0.
- `release.sh` argv checked with `printf '%q'` and an argument count: `patch` and `prerelease` both yield 6 arguments with no empty element, `prerelease beta` yields 8 with `--preid beta` in position. 0 or 3+ arguments print usage and exit 1.
- `bash -n` clean, workflow still parses as valid YAML with all four `build` run-steps intact.

Existing alpha behaviour is unchanged: `v*-alpha*` still publishes to the `alpha` dist-tag.

## Not included

npm trusted publishing needs no per-channel setup — the OIDC exchange is dist-tag agnostic, and provenance is unaffected. Cross-package deps also already work: `workspace:^5.7.1` is rewritten at publish time to `^5.8.0-beta.0`, and a caret range whose comparator carries a prerelease matches prereleases of that same version tuple, so `@codspeed/vitest-plugin@beta` resolves `@codspeed/core@beta`.

Consuming prerelease versions of the benchmark frameworks themselves (for example `vitest@4.0.0-beta.1` against the `vitest: "^3.2 || ^4"` peer range) is a separate concern and untouched here.

## Consistency with the other CodSpeed repos

Beta is the normal prerelease channel elsewhere; codspeed-node was the only repo that could not produce one.

| repo | prereleases supported | how it is cut | GitHub release flagged | prereleases historically shipped |
| --- | --- | --- | --- | --- |
| runner | yes, first-class | `cargo release --execute beta` | yes, `announcement_is_prerelease` from cargo-dist | 39 `-beta`, 24 `-alpha` tags |
| pytest-codspeed | yes | `uvx bumpver update --minor --tag beta` | no | 9 `-beta` tags |
| codspeed-rust | no | not supported by `scripts/release.sh` | no | 4 `-alpha` tags, 2023 only |
| codspeed-node (before) | alpha only, by accident | not reachable through `scripts/release.sh` | no | 2 `-alpha` tags |

Details worth carrying over or noting:

- The runner keeps a prerelease from becoming the default install by gating `gh release edit --latest` and the downstream `CodSpeedHQ/action` version bump on `announcement_is_prerelease` (`.github/workflows/post-announce.yml:24-50`). npm's dist-tag gives us the equivalent for free, which is what this PR wires up.
- Both the runner (`scripts/pre-release.sh:6-10`) and pytest-codspeed (`scripts/pre-release.sh:6-8`) skip changelog generation for `alpha`/`beta`/`rc`. Not applicable here: this repo generates no changelog.
- `scripts/release.sh` in this repo is a sibling of the codspeed-rust one, which explains the shared `<major|minor|patch>`-only shape. codspeed-rust has the same gap if it ever needs a prerelease.
- The missing `--prerelease` on the draft GitHub release is not unique to us: pytest-codspeed and codspeed-rust omit it too.

The `CONTRIBUTING.md` added here follows the structure of the runner and pytest-codspeed guides, and documents what the prerelease identifier is, since neither of those explains it.
