### PR TITLE
fix(core): load the native addon on every Node major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,46 @@ jobs:
       - run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm turbo run lint typecheck test
 
+  native-abi:
+    runs-on: "ubuntu-latest"
+    name: Native addon ABI compatibility
+    env:
+      # The flags the runner passes in a real benchmark process. They cannot go
+      # through NODE_OPTIONS (--allow-natives-syntax is rejected there), so jest
+      # runs in-band under a flagged node instead of forking workers.
+      NODE_OPTS: "--interpreted-frames-native-stack --allow-natives-syntax"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+      - name: Restore turbo cache
+        uses: ./.github/actions/turbo-cache
+        with:
+          key-suffix: native-abi
+      - run: pnpm install --frozen-lockfile --prefer-offline
+      # Build one prebuild set, then load it without rebuilding under each
+      # runtime via the jest integ test. The other jobs compile the addon
+      # with the Node version that loads it, so they cannot detect an ABI
+      # mismatch.
+      - run: pnpm turbo run build --filter=@codspeed/core
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - run: node ${{ env.NODE_OPTS }} "$(node -p 'require.resolve("jest/bin/jest")')" -c jest.config.integ.js --runInBand tests/index.integ.test.ts
+        working-directory: packages/core
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - run: node ${{ env.NODE_OPTS }} "$(node -p 'require.resolve("jest/bin/jest")')" -c jest.config.integ.js --runInBand tests/index.integ.test.ts
+        working-directory: packages/core
+
   list-examples:
     runs-on: "ubuntu-latest"
     name: List examples

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   "gypfile": true,
   "scripts": {
     "build": "rollup -c",
-    "build-native-addon": "prebuildify --name node --strip --no-napi --target 22.0.0 --target 24.0.0",
+    "build-native-addon": "prebuildify --name node.napi --napi --strip --target 22.0.0",
     "build-tracer-client": "openapi --client axios --input ./tracer.spec.json --name MongoTracer --output ./src/generated/openapi",
     "test": "jest --passWithNoTests --silent",
     "test/integ": "jest --passWithNoTests --silent -c jest.config.integ.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,8 +16,12 @@ export const setupCore = () => {
   warnOnUnsupportedNodeVersion();
 
   if (!native_core.isBound) {
+    const reason =
+      native_core.bindError instanceof Error
+        ? native_core.bindError.message
+        : String(native_core.bindError);
     throw new Error(
-      "Native core module is not bound, CodSpeed integration will not work properly",
+      `Native core module is not bound, CodSpeed integration will not work properly (Node ${process.version}, ABI ${process.versions.modules}, ${process.platform}-${process.arch}): ${reason}`,
     );
   }
 

--- a/packages/core/src/native_core/index.ts
+++ b/packages/core/src/native_core/index.ts
@@ -9,6 +9,7 @@ interface NativeCore {
 
 interface NativeCoreWithBindingStatus extends NativeCore {
   isBound: boolean;
+  bindError?: unknown;
 }
 
 let native_core: NativeCoreWithBindingStatus;
@@ -76,6 +77,7 @@ try {
       MARKER_TYPE_BENCHMARK_END: 3,
     },
     isBound: false,
+    bindError: e,
   };
 }
 

--- a/packages/core/src/native_core/linux_perf/linux_perf.cc
+++ b/packages/core/src/native_core/linux_perf/linux_perf.cc
@@ -22,7 +22,7 @@ LinuxPerf::LinuxPerf(const Napi::CallbackInfo &info)
 Napi::Value LinuxPerf::Start(const Napi::CallbackInfo &info) {
   if (handler == nullptr) {
     v8::Isolate *isolate = v8::Isolate::GetCurrent();
-    handler = new LinuxPerfHandler(isolate);
+    handler = new LinuxPerfHandler(isolate, info.Env());
     handler->Enable();
     return Napi::Boolean::New(info.Env(), true);
   }

--- a/packages/core/src/native_core/linux_perf/linux_perf.h
+++ b/packages/core/src/native_core/linux_perf/linux_perf.h
@@ -10,7 +10,7 @@ namespace codspeed_native {
 
 class LinuxPerfHandler : public v8::CodeEventHandler {
 public:
-  explicit LinuxPerfHandler(v8::Isolate *isolate);
+  LinuxPerfHandler(v8::Isolate *isolate, napi_env env);
   ~LinuxPerfHandler() override;
 
   void Handle(v8::CodeEvent *code_event) override;
@@ -19,6 +19,7 @@ private:
   std::ofstream mapFile;
   std::string FormatName(v8::CodeEvent *code_event);
   v8::Isolate *isolate_;
+  napi_env env_;
 };
 
 class LinuxPerf : public Napi::ObjectWrap<LinuxPerf> {

--- a/packages/core/src/native_core/linux_perf/linux_perf_listener.cc
+++ b/packages/core/src/native_core/linux_perf/linux_perf_listener.cc
@@ -5,9 +5,10 @@
 
 namespace codspeed_native {
 
-LinuxPerfHandler::LinuxPerfHandler(v8::Isolate *isolate)
+LinuxPerfHandler::LinuxPerfHandler(v8::Isolate *isolate, napi_env env)
     : v8::CodeEventHandler(isolate) {
   isolate_ = isolate;
+  env_ = env;
   int pid = static_cast<int>(uv_os_getpid());
   mapFile.open("/tmp/perf-" + std::to_string(pid) + ".map");
 }
@@ -17,7 +18,7 @@ LinuxPerfHandler::~LinuxPerfHandler() { mapFile.close(); }
 std::string LinuxPerfHandler::FormatName(v8::CodeEvent *code_event) {
   std::string name = std::string(code_event->GetComment());
   if (name.empty()) {
-    name = v8LocalStringToString(code_event->GetFunctionName());
+    name = v8LocalStringToString(env_, code_event->GetFunctionName());
   }
   return name;
 }
@@ -27,7 +28,8 @@ void LinuxPerfHandler::Handle(v8::CodeEvent *code_event) {
           << code_event->GetCodeSize() << " ";
   mapFile << v8::CodeEvent::GetCodeEventTypeName(code_event->GetCodeType())
           << ":" << FormatName(code_event) << " "
-          << v8LocalStringToString(code_event->GetScriptName()) << std::dec
+          << v8LocalStringToString(env_, code_event->GetScriptName())
+          << std::dec
           << ":" << code_event->GetScriptLine() << ":"
           << code_event->GetScriptColumn() << std::endl;
 }

--- a/packages/core/src/native_core/linux_perf/utils.h
+++ b/packages/core/src/native_core/linux_perf/utils.h
@@ -2,14 +2,34 @@
 #define LINUX_PERF_UTILS_H
 
 #include "v8-profiler.h"
+#include <js_native_api.h>
+#include <string>
 
+// The string conversions are the only part of the V8 C++ API used here that is
+// not ABI-stable: Utf8Value's constructor gained a defaulted argument in Node
+// 24, and WriteUtf8 gave way to WriteUtf8V2 in Node 26, so none of them
+// resolves on every major. Node-API is versioned and does not move, and
+// napi_value is layout-compatible with v8::Local<v8::Value> by construction.
 static inline std::string
-v8LocalStringToString(v8::Local<v8::String> v8String) {
-  // Utf8Value NUL-terminates, so the c-string constructor stops at the first
-  // embedded NUL, as callers expect for symbol names. It yields nullptr when
-  // the conversion throws.
-  v8::String::Utf8Value value(v8::Isolate::GetCurrent(), v8String);
-  return *value ? std::string(*value) : std::string();
+v8LocalStringToString(napi_env env, v8::Local<v8::String> v8String) {
+  if (v8String.IsEmpty()) {
+    return std::string();
+  }
+
+  napi_value value = reinterpret_cast<napi_value>(*v8String);
+  size_t length = 0;
+  if (napi_get_value_string_utf8(env, value, nullptr, 0, &length) != napi_ok) {
+    return std::string();
+  }
+
+  std::string result(length + 1, '\0');
+  if (napi_get_value_string_utf8(env, value, result.data(), result.size(),
+                                 &length) != napi_ok) {
+    return std::string();
+  }
+
+  result.resize(length);
+  return result;
 }
 
 #endif // LINUX_PERF_UTILS_H

--- a/packages/core/src/nodeVersion.ts
+++ b/packages/core/src/nodeVersion.ts
@@ -1,8 +1,7 @@
 /**
- * Majors the native addon ships prebuilds for, as listed in the
- * `build-native-addon` targets in package.json. Prebuilds are matched on the
- * exact ABI version, so on any other major the addon only loads when it has
- * been compiled from source locally.
+ * Majors CodSpeed is tested against. The native addon itself is built as a
+ * single Node-API binary and loads on any major, so this only gates the
+ * warning about measurement stability.
  */
 export const SUPPORTED_NODE_MAJORS = [22, 24];
 

--- a/packages/core/tests/index.integ.test.ts
+++ b/packages/core/tests/index.integ.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-export {}; // Make this a module
+import fs from "fs";
 
 beforeEach(() => {
   jest.resetModules();
@@ -9,6 +9,25 @@ describe("with bindings", () => {
   it("should be bound", () => {
     const isBound = require("..").isBound as boolean;
     expect(isBound).toBe(true);
+  });
+
+  // Symbols in the addon are bound lazily, so a prebuild built against another
+  // ABI loads without complaint and only dies once a V8 entry point runs.
+  it("should write the perf map when the core is set up", () => {
+    const { setupCore, teardownCore } = require("..") as {
+      setupCore: () => void;
+      teardownCore: () => void;
+    };
+    setupCore();
+    teardownCore();
+
+    const perfMap = `/tmp/perf-${process.pid}.map`;
+    const entries = fs
+      .readFileSync(perfMap, "utf8")
+      .split("\n")
+      .filter(Boolean);
+    fs.unlinkSync(perfMap);
+    expect(entries.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
Ship a single Node-API prebuild for the native core, so one binary covers both supported Node majors instead of one binary per ABI.

Since `c5c63ca` the addon has shipped ABI-pinned prebuilds (`node.abi127.node`, `node.abi137.node`). `node-gyp-build` matches those on an exact `process.versions.modules`, so on any other major it finds no candidate, `native_core` silently falls back to the no-op stub, and every benchmark dies with `Native core module is not bound, CodSpeed integration will not work properly`. That contradicts what `nodeVersion.ts` already tells users, which is that other versions are experimental rather than fatal.

Only one V8 entry point stood in the way of a single prebuild. `v8::String::Utf8Value`'s constructor gained a defaulted `WriteOptions` argument in Node 24, and `WriteUtf8` gave way to `WriteUtf8V2` in Node 26, so no single string-conversion symbol resolves across majors:

| symbol | 22 | 24 | 26 |
| --- | --- | --- | --- |
| `String::Utf8Value::Utf8Value(Isolate*, Local<Value>)` | yes | no | yes |
| `String::Utf8Length` / `String::WriteUtf8` | yes | yes | no |
| `String::WriteUtf8V2` | no | yes | yes |

Note the middle row: reverting to the pre-`c591e88` formulation would satisfy 22 and 24 today, but it is the one that V8 has already removed, so it re-arms the same failure for the next bump. The other fourteen V8 symbols the perf-map handler needs (`CodeEventHandler` ctor/dtor/`Enable`/`Disable`, the eight `CodeEvent` getters, `Isolate::GetCurrent`) are present in every binary checked. So the conversion goes through Node-API, which is versioned and does not move.

Two packaging details worth attention during review:

- prebuildify 6 defaults `--name` to the package name and dropped the `napi` filename tag, contradicting its own README. A bare `--napi` emits `@codspeed+core.node` or `node.node`, both of which `node-gyp-build@4.6.0` rejects (`if (tags.abi !== abi && !tags.napi) return false`). Hence the explicit `--name node.napi`.
- The target is pinned to `22.0.0` so we compile against the oldest supported headers rather than whatever `node-abi` currently believes is newest, which today is 26.

`setupCore` also now reports the underlying `require` failure plus the Node version, ABI and platform. Previously it went to `logDebug`, which is why the original report gave nothing to work from.

### Why CI did not catch this

The `node-versions` job runs `pnpm turbo run build`, which includes `build-native-addon`, under the same Node it then benchmarks with. The addon is always compiled for the running ABI, so an incompatible prebuild is structurally unobservable there. The new `native-abi` job builds one prebuild set and loads it from Node 22 and 24, calling `setupCore` because the symbols bind lazily: a broken addon passes a bare `require` and only dies once `LinuxPerf::Start` runs.

Verified locally against both failure modes on a from-scratch build:

- ABI-pinned prebuild for 22 only: Node 24 exits 1 with the new diagnostic naming the missing ABI.
- `--napi` with the old `Utf8Value` call: Node 24 exits 127 on `undefined symbol: _ZN2v86String9Utf8ValueC1EPNS_7IsolateENS_5LocalINS_5ValueEEE`, while 22 passes.
- With the fix, one artifact passes on 22 and 24.

### Scope

Both designs satisfy the 22 and 24 requirement, so the argument for this one is what happens outside it: users on another major degrade with the existing experimental-version warning instead of hitting an unreadable stub failure, and the package ships three prebuilt binaries instead of six. The tradeoff is that the two supported majors now share one binary and therefore depend on those fourteen V8 symbols staying put, rather than each being compiled against its own headers. That is the same bet the v5 line ran successfully for three years, and the new job fails loudly if it ever stops holding.

This does not remove the V8 C++ dependency. Retiring it entirely means dropping `LinuxPerf` for `--perf-basic-prof`, which the walltime path already uses and which writes the same `/tmp/perf-<pid>.map`.
